### PR TITLE
Calculating available free RAM fix

### DIFF
--- a/VelvetOpt/Utils.pm
+++ b/VelvetOpt/Utils.pm
@@ -73,10 +73,8 @@ sub num_cpu {
 
 sub free_mem {
 	if( $^O =~ m/linux/i ) {
-		my $x       = `free | grep '^Mem:' | sed 's/  */~/g' | cut -d '~' -f 4,7`;
-		my @tmp     = split "~", $x;
-		my $total   = $tmp[0] + $tmp[1];
-		my $totalGB = $total / 1024 / 1024;
+		my $avail   = `free | grep '^Mem:' | sed 's/  */~/g' | cut -d '~' -f 7`;
+		my $totalGB = $avail / 1024 / 1024;
 		return $totalGB;
 	}
 	elsif( $^O =~ m/darwin/i){


### PR DESCRIPTION
At the moment, the subroutine sums together columns four and seven from the 'free' command. From the man page, column 4 is the "unused memory (MemFree and SwapFree in /proc/meminfo)". Column seven is an "(e)stimation  of  how  much  memory is available for starting new applications, without swapping. Unlike the data provided by the cache or free fields, this field takes into account page cache and also that not all reclaimable memory slabs will be reclaimed due to items being in use".

At the moment, in adding these together, VO effectively overestimates by a factor of approx 2 the amount of free memory available to VelvetOptimiser. This commit readjusts to only take the seventh column.