### PR TITLE
Fix crash when filename contains dash

### DIFF
--- a/VelvetOpt/hwrap.pm
+++ b/VelvetOpt/hwrap.pm
@@ -238,7 +238,7 @@ sub _checkVHString {
 	#get each m/-options+ filename+/ block
 	my @blocks;
     $line =~ s/^/ /;
-    while ($line =~ m/(\b(-[\w\d]+\s+)+[\w\/\\\. ]+)/g) {
+    while ($line =~ m/(\b(-[\w\d]+\s+)+[-\w\/\\\. ]+)/g) {
 		my $text = $1;
         $text =~ s/\s+$//;
 		push @blocks, $text;


### PR DESCRIPTION
Hi,

I'm trying to use the https://galaxyproject.github.io/training-material/topics/assembly/tutorials/debruijn-graph-assembly/tutorial.html tutorial (preparing for a training session at the end of the month)

I had a crash of velvetoptimiser because our galaxy server is installed in a path with a dash (/opt/galaxy-dist):

```
Fatal error: Exit code 2 ()

****************************************************
           VelvetOptimiser.pl Version 2.2.5
****************************************************
Number of CPUs available: 10
Current free RAM: 47.052GB
Velvet OMP compiler setting: 2
Oct  2 17:06:13 Starting to check input parameters.
*** 1 files specified for -separate option in block: -fastq   -shortPaired  -separate /opt/galaxy. Require exactly 2.
 at /opt/galaxy-dist/conda/envs/mulled-v1-6487bd322a704c25a7d7ff8eed84db64d562929ef48f39b2bd4c32f5535f3181/bin/VelvetOptimiser.pl line 490.
*** File /opt/galaxy doesn't exist or is unreadable.
 at /opt/galaxy-dist/conda/envs/mulled-v1-6487bd322a704c25a7d7ff8eed84db64d562929ef48f39b2bd4c32f5535f3181/bin/VelvetOptimiser.pl line 490.
Block -fastq   -shortPaired  -separate /opt/galaxy FAILED!
*** Unknown option used: -dist/database/files/002/058/dataset_2058865.dat in file block: -dist/database/files/002/058/dataset_2058865.dat /opt/galaxy
 at /opt/galaxy-dist/conda/envs/mulled-v1-6487bd322a704c25a7d7ff8eed84db64d562929ef48f39b2bd4c32f5535f3181/bin/VelvetOptimiser.pl line 490.
*** File /opt/galaxy doesn't exist or is unreadable.
 at /opt/galaxy-dist/conda/envs/mulled-v1-6487bd322a704c25a7d7ff8eed84db64d562929ef48f39b2bd4c32f5535f3181/bin/VelvetOptimiser.pl line 490.
Block -dist/database/files/002/058/dataset_2058865.dat /opt/galaxy FAILED!
*** Unknown option used: -dist/database/files/002/058/dataset_2058866.dat in file block: -dist/database/files/002/058/dataset_2058866.dat
 at /opt/galaxy-dist/conda/envs/mulled-v1-6487bd322a704c25a7d7ff8eed84db64d562929ef48f39b2bd4c32f5535f3181/bin/VelvetOptimiser.pl line 490.
Block -dist/database/files/002/058/dataset_2058866.dat FAILED!
Please re-start with a corrected velveth parameter string. at /opt/galaxy-dist/conda/envs/mulled-v1-6487bd322a704c25a7d7ff8eed84db64d562929ef48f39b2bd4c32f5535f3181/bin/VelvetOptimiser.pl line 492.
```

Here's a patch which fixes the problem (I just hope it doesn't break anything else)

By the way, I saw this old PR for galaxy tools: https://github.com/galaxyproject/tools-iuc/pull/862
Do you still have plans to work on it? Now that we can get rid of tool_dependencies.xml I think it would be easier to finish. I can help if it's needed

Cheers